### PR TITLE
Ajuste de algumas validações

### DIFF
--- a/src/Elements/Z50.php
+++ b/src/Elements/Z50.php
@@ -48,7 +48,7 @@ class Z50 extends Element implements ElementInterface
         ],
         'UF' => [
             'type' => 'string',
-            'regex' => '^(AC|AL|AM|AP|BA|CE|DF|ES|GO|MA|MG|MS|MT|PA|PB|PE|PI|PR|RJ|RN|RO|RR|RS|SC|SE|SP|TO)$',
+            'regex' => '^(AC|AL|AM|AP|BA|CE|DF|ES|GO|MA|MG|MS|MT|PA|PB|PE|PI|PR|RJ|RN|RO|RR|RS|SC|SE|SP|TO|EX)$',
             'required' => true,
             'info' => 'Sigla da Unidade da Federação do emitente',
             'format' => 'empty',

--- a/src/Elements/Z51.php
+++ b/src/Elements/Z51.php
@@ -55,7 +55,7 @@ class Z51 extends Element implements ElementInterface
         ],
         'UF' => [
             'type' => 'string',
-            'regex' => '^(AC|AL|AM|AP|BA|CE|DF|ES|GO|MA|MG|MS|MT|PA|PB|PE|PI|PR|RJ|RN|RO|RR|RS|SC|SE|SP|TO)$',
+            'regex' => '^(AC|AL|AM|AP|BA|CE|DF|ES|GO|MA|MG|MS|MT|PA|PB|PE|PI|PR|RJ|RN|RO|RR|RS|SC|SE|SP|TO|EX)$',
             'required' => true,
             'info' => 'Sigla da Unidade da Federação do remetente',
             'format' => '',

--- a/src/Elements/Z54.php
+++ b/src/Elements/Z54.php
@@ -65,7 +65,7 @@ class Z54 extends Element implements ElementInterface
             'regex' => '^.{1,3}$',
             'required' => true,
             'info' => 'Código da Situação Tributária',
-            'format' => 'totalNumber',
+            'format' => '',
             'length' => 3
         ],
         'NUMERO_ITEM' => [

--- a/src/Elements/Z70.php
+++ b/src/Elements/Z70.php
@@ -40,7 +40,7 @@ class Z70 extends Element implements ElementInterface
         ],
         'UF' => [
             'type' => 'string',
-            'regex' => '^(AC|AL|AM|AP|BA|CE|DF|ES|GO|MA|MG|MS|MT|PA|PB|PE|PI|PR|RJ|RN|RO|RR|RS|SC|SE|SP|TO)$',
+            'regex' => '^(AC|AL|AM|AP|BA|CE|DF|ES|GO|MA|MG|MS|MT|PA|PB|PE|PI|PR|RJ|RN|RO|RR|RS|SC|SE|SP|TO|EX)$',
             'required' => true,
             'info' => 'Sigla da Unidade da Federação do emitente',
             'format' => 'empty',

--- a/src/Elements/Z74.php
+++ b/src/Elements/Z74.php
@@ -73,7 +73,7 @@ class Z74 extends Element implements ElementInterface
         ],
         'UF' => [
             'type' => 'string',
-            'regex' => '^(AC|AL|AM|AP|BA|CE|DF|ES|GO|MA|MG|MS|MT|PA|PB|PE|PI|PR|RJ|RN|RO|RR|RS|SC|SE|SP|TO)$',
+            'regex' => '^(AC|AL|AM|AP|BA|CE|DF|ES|GO|MA|MG|MS|MT|PA|PB|PE|PI|PR|RJ|RN|RO|RR|RS|SC|SE|SP|TO|EX)$',
             'required' => true,
             'info' => 'UF do possuidor/proprietário',
             'format' => 'empty',

--- a/src/Elements/Z74.php
+++ b/src/Elements/Z74.php
@@ -65,7 +65,7 @@ class Z74 extends Element implements ElementInterface
         ],
         'IE' => [
             'type' => 'string',
-            'regex' => '^ISENTO|[0-9]{2,14}$',
+            'regex' => '^ISENTO|[0-9]{0,14}$',
             'required' => false,
             'info' => 'Inscrição estadual do possuidor / proprietário',
             'format' => '',

--- a/src/Elements/Z76.php
+++ b/src/Elements/Z76.php
@@ -89,7 +89,7 @@ class Z76 extends Element implements ElementInterface
         ],
         'UF' => [
             'type' => 'string',
-            'regex' => '^(AC|AL|AM|AP|BA|CE|DF|ES|GO|MA|MG|MS|MT|PA|PB|PE|PI|PR|RJ|RN|RO|RR|RS|SC|SE|SP|TO)$',
+            'regex' => '^(AC|AL|AM|AP|BA|CE|DF|ES|GO|MA|MG|MS|MT|PA|PB|PE|PI|PR|RJ|RN|RO|RR|RS|SC|SE|SP|TO|EX)$',
             'required' => true,
             'info' => 'Sigla da Unidade da Federação do remetente',
             'format' => 'empty',


### PR DESCRIPTION
> Explicação das validações

- Adicionado no regex da UF o valor 'EX' para os Registros 50, 51, 70, 74 e 76, pois a UF pode ser de um cliente estrangeiro, ou se tratar de uma exportação, portanto deve ser informada como 'EX';
![Sem título](https://user-images.githubusercontent.com/77071812/134002061-31460662-4001-46cc-bcb2-93465f0f7d57.png)
- Ajustado a regra de formatação no campo CST no registro 54, pois o mesmo deve ser branco e não '000', quando o NUMERO_ITEM > 990. Segue print da validação abaixo:
![image](https://user-images.githubusercontent.com/77071812/134001066-1993e9aa-b2b5-4c54-9cc1-30c54fee7941.png)
- Ajustado a regra da IE para o registro 74 (inventário), onde o validador aponta a IE como inválida, mesmo estando correta para a UF informada. Deixando o campo em branco, o validador aceita sem avisos.
![Sem título](https://user-images.githubusercontent.com/77071812/134001839-8110464f-56b2-4b74-945a-4df731735e80.png)

Caso houver alguma dúvida, estarei a disposição.

desenvolvimento3@smallsoft.com.br