### PR TITLE
Corrigido layout de geração do bloco 61R

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Todas as atualizações a partir de 30/05/2016 devem observar os princípios [Ma
 ## 5.0.0-dev
 
 ## Notas da versão:
-Esta release quebra a compatibilidade com as versões anteriores e contêm várias mudanças em relação a forma de configuração e uso.
+Esta release quebra a compatibilidade com as versões anteriores e contêm várias mudanças em relação à forma de configuração e uso.
 ### Added
 - Nothing
 

--- a/src/Elements/Z61R.php
+++ b/src/Elements/Z61R.php
@@ -15,7 +15,6 @@ use \stdClass;
 class Z61R extends Element implements ElementInterface
 {
     const REGISTRO = '61';
-    protected $subtipo = 'R';
 
     protected $parameters = [
         'MESTRE' => [

--- a/src/Elements/Z61R.php
+++ b/src/Elements/Z61R.php
@@ -79,7 +79,7 @@ class Z61R extends Element implements ElementInterface
             'required' => false,
             'info' => 'Brancos',
             'format' => 'empty',
-            'length' => 53
+            'length' => 54
         ]
     ];
 


### PR DESCRIPTION
De acordo com a documentação, este registro não possui subtipo.