### PR TITLE
Correções na geração do bloco 61R

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Todas as atualizações a partir de 30/05/2016 devem observar os princípios [Ma
 ## 5.0.0-dev
 
 ## Notas da versão:
-Esta release quebra a compatibilidade com as versões anteriores e contêm várias mudanças em relação a forma de configuração e uso.
+Esta release quebra a compatibilidade com as versões anteriores e contêm várias mudanças em relação à forma de configuração e uso.
 ### Added
 - Nothing
 

--- a/src/Blocks/Block6.php
+++ b/src/Blocks/Block6.php
@@ -17,6 +17,6 @@ final class Block6 extends Block implements BlockInterface
     public $elements = [
         'z60' => ['class' => Elements\Z60M::class, 'level' => 0, 'type' => 'single'],
         'z61' => ['class' => Elements\Z61::class, 'level' => 0, 'type' => 'single'],
-        'z61R' => ['class' => Elements\Z61R::class, 'level' => 0, 'type' => 'single'],
+        'z61r' => ['class' => Elements\Z61R::class, 'level' => 0, 'type' => 'single'],
     ];
 }

--- a/src/Elements/Z61R.php
+++ b/src/Elements/Z61R.php
@@ -15,7 +15,6 @@ use \stdClass;
 class Z61R extends Element implements ElementInterface
 {
     const REGISTRO = '61';
-    protected $subtipo = 'R';
 
     protected $parameters = [
         'MESTRE' => [

--- a/src/Elements/Z61R.php
+++ b/src/Elements/Z61R.php
@@ -79,7 +79,7 @@ class Z61R extends Element implements ElementInterface
             'required' => false,
             'info' => 'Brancos',
             'format' => 'empty',
-            'length' => 53
+            'length' => 54
         ]
     ];
 


### PR DESCRIPTION
Conforme a documentação abaixo, o registro 61R não possui subtipo. Também foi alterado a quantidade de caractere de dos brancos para 54 conforme mostrado na documentação.

![image](https://user-images.githubusercontent.com/54853479/134936914-b5af441c-186f-439f-b6a9-4172b2820bde.png)
